### PR TITLE
Prevent endless await if error during decoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ export default class AudioSVGWaveform {
         const response = await fetch(this.url);
         const arrayBuffer = await parseArrayBufferResponse(response);
 
-        this.audioBuffer = await this.context.decodeAudioData(arrayBuffer);
+        this.audioBuffer = await this.context.decodeAudioData(arrayBuffer).catch(()=>{return null};
 
         return this.audioBuffer;
     }


### PR DESCRIPTION
If a response doesn't contain an audio track or the track was corrupt, the await condition would never return.